### PR TITLE
Remove GitHub Tagging step

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -144,15 +144,6 @@ jobs:
           annotations: ${{ steps.meta.outputs.annotations }}
           labels: ${{ steps.meta.outputs.labels }}
           platforms: ${{ env.PLATFORMS }}
-      - name: Create Git Tag
-        uses: mathieudutour/github-tag-action@a22cf08638b34d5badda920f9daf6e72c477b07b
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          default_bump: false
-          default_prerelease_bump: false
-          custom_tag: ${{ steps.check-image.outputs.tag }}
-          dry_run: ${{ github.event_name == 'pull_request' }}
-          tag_prefix: ""
       - name: Create GitHub Release
         if: ${{ github.event_name != 'pull_request' }}
         uses: comnoco/create-release-action@6ac85b5a67d93e181c1a8f97072e2e3ffc582ec4

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ ARG APOLLO_ROUTER_VERSION=2.2.1
 # renovate: datasource=github-releases depName=apollographql/apollo-mcp-server
 ARG APOLLO_MCP_SERVER_VERSION=0.3.0
 
-LABEL org.opencontainers.image.version=0.0.3
+LABEL org.opencontainers.image.version=0.0.4
 LABEL org.opencontainers.image.vendor="Apollo GraphQL"
 LABEL org.opencontainers.image.title="Apollo Runtime"
 LABEL org.opencontainers.image.description="A GraphQL Runtime for serving Supergraphs and enabling AI"


### PR DESCRIPTION
Creating a release when a tag doesn't exist will create the tag so we don't need this separate step, and further this step is also unmaintained so getting rid of a dependency is a good idea