### PR TITLE
Propagate the name change and reset versioning

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,4 +1,4 @@
-name: Build GraphOS Runtime Container
+name: Build Apollo Runtime Container
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
@@ -10,7 +10,7 @@ on:
   pull_request:
 env:
   REGISTRY: ghcr.io
-  NAMESPACED_REGISTRY: ghcr.io/apollographql/graphos-runtime
+  NAMESPACED_REGISTRY: ghcr.io/apollographql/apollo-runtime
   PLATFORMS: linux/arm64,linux/amd64
 
 jobs:
@@ -151,6 +151,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           tag_name: ${{ steps.check-image.outputs.tag }}
-          release_name: Apollo GraphOS Runtime Container - v${{ steps.calculate-version.outputs.correct_version }} (Router - v${{ fromJSON(steps.get-versions.outputs.versions).APOLLO_ROUTER_VERSION }}, MCP Server - v${{ fromJSON(steps.get-versions.outputs.versions).APOLLO_MCP_SERVER_VERSION }})
+          release_name: Apollo Runtime Container - v${{ steps.calculate-version.outputs.correct_version }} (Router - v${{ fromJSON(steps.get-versions.outputs.versions).APOLLO_ROUTER_VERSION }}, MCP Server - v${{ fromJSON(steps.get-versions.outputs.versions).APOLLO_MCP_SERVER_VERSION }})
           body: Find the latest release at ${{ env.NAMESPACED_REGISTRY }}:${{ steps.check-image.outputs.tag }}.
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,9 +8,9 @@ ARG APOLLO_ROUTER_VERSION=2.3.0
 # renovate: datasource=github-releases depName=apollographql/apollo-mcp-server
 ARG APOLLO_MCP_SERVER_VERSION=0.3.0
 
-LABEL org.opencontainers.image.version=0.0.3
+LABEL org.opencontainers.image.version=0.0.1
 LABEL org.opencontainers.image.vendor="Apollo GraphQL"
-LABEL org.opencontainers.image.title="Apollo GraphOS Runtime"
+LABEL org.opencontainers.image.title="Apollo Runtime"
 LABEL org.opencontainers.image.description="A GraphQL Runtime for serving Supergraphs and enabling AI"
 LABEL com.apollographql.router.version=$APOLLO_ROUTER_VERSION
 LABEL com.apollographql.mcp-server.version=$APOLLO_MCP_SERVER_VERSION

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Apollo Graph, Inc
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Apollo GraphOS Runtime Container
+# Apollo Runtime Container
 
-A container that has all the required utilities to run the Apollo GraphOS Runtime, including our new MCP Server.
+A container that has all the required utilities to run the Apollo Runtime, including our new MCP Server.
 
 ## Container Tags
 
@@ -13,9 +13,9 @@ and the MCP Server version, each separated by underscores.
 This leads to different tags that will pin different versions of the runtime components as well as the container itself.
 
 For example:
-* `ghcr.io/apollographql/graphos-runtime:latest` - This will give the latest of all components and the runtime container
-* `ghcr.io/apollographql/graphos-runtime:v0.1.0_router2.1.2` - This will pin the runtime container version and the router version, but always get the latest `mcp-server` version
-* `ghcr.io/apollographql/graphos-runtime:latest_router2.1.2_mcp-server0.2.1` - This will pin Router and MCP Server versions but not the runtime container version
+* `ghcr.io/apollographql/apollo-runtime:latest` - This will give the latest of all components and the runtime container
+* `ghcr.io/apollographql/apollo-runtime:v0.1.0_router2.1.2` - This will pin the runtime container version and the router version, but always get the latest `mcp-server` version
+* `ghcr.io/apollographql/apollo-runtime:latest_router2.1.2_mcp-server0.2.1` - This will pin Router and MCP Server versions but not the runtime container version
 
 ## Running The Container
 
@@ -31,7 +31,7 @@ docker run \
 --rm \
 -p 4000:4000 \
 -p 5000:5000 \
-ghcr.io/apollographql/graphos-runtime:latest
+ghcr.io/apollographql/apollo-runtime:latest
 ```
 We open two ports in the above command:
 - 4000 is where the router is listening. Make your GraphQL queries here.


### PR DESCRIPTION
Now that the repo is public, and the name has changed we should fix up the documentation and ensure our publishing still works correctly. We can also reset the container version (as this is effectively new).