### PR TITLE
Move to port 5050 for MacOS compatability

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ ARG APOLLO_ROUTER_VERSION=2.3.0
 # renovate: datasource=github-releases depName=apollographql/apollo-mcp-server
 ARG APOLLO_MCP_SERVER_VERSION=0.3.0
 
-LABEL org.opencontainers.image.version=0.0.3
+LABEL org.opencontainers.image.version=0.0.4
 LABEL org.opencontainers.image.vendor="Apollo GraphQL"
 LABEL org.opencontainers.image.title="Apollo Runtime"
 LABEL org.opencontainers.image.description="A GraphQL Runtime for serving Supergraphs and enabling AI"

--- a/README.md
+++ b/README.md
@@ -30,12 +30,12 @@ docker run \
 --env MCP_ENABLE=1 \
 --rm \
 -p 4000:4000 \
--p 5000:5000 \
+-p 5050:5000 \
 ghcr.io/apollographql/apollo-runtime:latest
 ```
 We open two ports in the above command:
 - 4000 is where the router is listening. Make your GraphQL queries here.
-- 5000 is where the MCP server is mounted, specifically at the `/mcp` path. Connect your assistants to this port.
+- 5050 is where the MCP server is mounted, specifically at the `/mcp` path. Connect your assistants to this port.
 
 ### Running the MCP Server
 

--- a/examples/compose.yaml
+++ b/examples/compose.yaml
@@ -4,7 +4,7 @@ services:
     build: ..
     ports:
       - "4000:4000"
-      - "5000:5000"
+      - "5050:5000"
     volumes:
       - type: bind
         source: ./router_config.yaml


### PR DESCRIPTION
Fixes #12 

Move our instructions/examples to port 5050 instead of 5000 just to avoid the MacOS compatibility issues