### PR TITLE
feat!: use new config file for MCP

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,9 +6,9 @@ ARG S6_OVERLAY_VERSION=3.2.1.0
 # renovate: datasource=github-releases depName=apollographql/router
 ARG APOLLO_ROUTER_VERSION=2.3.0
 # renovate: datasource=github-releases depName=apollographql/apollo-mcp-server
-ARG APOLLO_MCP_SERVER_VERSION=0.5.2
+ARG APOLLO_MCP_SERVER_VERSION=0.6.0
 
-LABEL org.opencontainers.image.version=0.0.5
+LABEL org.opencontainers.image.version=0.0.6
 LABEL org.opencontainers.image.vendor="Apollo GraphQL"
 LABEL org.opencontainers.image.title="Apollo Runtime"
 LABEL org.opencontainers.image.description="A GraphQL Runtime for serving Supergraphs and enabling AI"

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ If you wish to enable it for testing purposes then set the environment variable 
 ...
 ```
 
-See [below](#configuring-using-environment-variables) for information on configuring the MCP Server
+See the example [config file](config/mcp_config.yaml) for information on configuring the MCP Server.
 
 ## Configuring Using Local Files
 
@@ -149,14 +149,4 @@ these are as follows:
 |----------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | `APOLLO_KEY`                     | A valid API Key for Apollo Studio                                                                                                                                      |
 | `APOLLO_GRAPH_REF`               | The Graph Ref in Apollo Studio referenced by the Router and MCP Server                                                                                                 |
-| `MCP_ALLOW_MUTATIONS`            | Possible values: `none`, don't allow any mutations, `explicit` allow explicit mutations, but don't allow the LLM to build them, `all` Allow the LLM to build mutations |
-| `MCP_COLLECTION`                 | The ID of an operation collection to use as the source for operations  (requires `APOLLO_KEY`).                                                                        |
-| `MCP_DISABLE_TYPE_DESCRIPTION`   | Disable operation root field types in tool description                                                                                                                 |
-| `MCP_DISABLE_SCHEMA_DESCRIPTION` | Disable schema type definitions referenced by all fields returned by the operation in the tool description                                                             |
 | `MCP_ENABLE`                     | Enable the MCP Server                                                                                                                                                  |
-| `MCP_EXPLORER`                   | Expose a tool that returns the URL to open a GraphQL operation in Apollo Explorer (requires `APOLLO_GRAPH_REF`)                                                        |
-| `MCP_HEADERS`                    | A list of comma separated, key value pairs (separated by `:`s), of headers to send to the GraphQL endpoint                                                             | 
-| `MCP_INTROSPECTION`              | Enable the `--introspection` option for the MCP Server                                                                                                                 |
-| `MCP_LOG_LEVEL`                  | Change the level at which the MCP Server logs, possible values: `ERROR`, `WARN`, `INFO`, `DEBUG`, `TRACE`                                                              |
-| `MCP_SSE`                        | Use SSE as the transport protocol rather than streamable HTTP                                                                                                          |
-| `MCP_UPLINK_MANIFEST`            | Enable use of Uplink to get the persisted queries (Requires `APOLLO_KEY` and `APOLLO_GRAPH_REF`)                                                            |

--- a/config/mcp_config.yaml
+++ b/config/mcp_config.yaml
@@ -1,0 +1,23 @@
+# yaml-language-server: $schema=../../mcp-apollo/schema.json
+
+################################################################################
+# Example MCP configuration
+#
+# Note that some of these options are overwritten by the run script depending on
+# the presence of certain files. Refer to the README for more information.
+################################################################################
+
+# Use uplink for operations
+operations:
+  source: uplink
+
+# Use uplink for schema information
+schema:
+  source: uplink
+
+# Configure the MCP server to listen for streamable HTTP messages on port 5000
+# for all addresses
+transport:
+  type: streamable_http
+  address: "0.0.0.0"
+  port: 5000

--- a/s6_service_definitions/mcp/run
+++ b/s6_service_definitions/mcp/run
@@ -3,72 +3,55 @@
 # Set our working directory
 cd /opt || exit
 
+LOCAL_CUSTOM_SCALARS="/config/custom_scalars.graphql"
+LOCAL_OPERATIONS="/config/operations"
+LOCAL_SCHEMA="/config/api_schema.graphql"
+LOCAL_PQ_MANIFEST="/config/persisted_queries_manifest.json"
+
+# Options set below are overrides using environment variables that match the
+# format expected by the MCP server, which is as follows:
+#
+# - The prefix `APOLLO_MCP_`
+# - The keys of the setting, separated by `__` for nesting
+#
+# e.g. The key `introspection.execute.enabled` would correspond to the env var
+# `APOLLO_MCP_INTROSPECTION__EXECUTE__ENABLED`.
+
 if [ -v MCP_ENABLE ]; then
+	# If the user has provided an API schema, then overwrite the default config
+	# option of using uplink to use the file instead
+	if [[ -f "$LOCAL_SCHEMA" ]]; then
+		echo "Using local API schema found at $LOCAL_SCHEMA instead of uplink. Delete this file to use uplink instead"
 
-  if [[ -f /config/api_schema.graphql ]]; then
-    ARGS+=(--schema /config/api_schema.graphql)
-  fi
+		export APOLLO_MCP_SCHEMA__SOURCE="local"
+		export APOLLO_MCP_SCHEMA__PATH="$LOCAL_SCHEMA"
+	fi
 
-  if [[ -f /config/custom_scalars.graphql ]]; then
-    ARGS+=(--custom-scalars-config /config/custom_scalars.graphql)
-  fi
+	# If the user has provided a custom scalar map, then overwrite the default config
+	# option of using uplink to use the supplied file instead
+	if [[ -f "$LOCAL_CUSTOM_SCALARS" ]]; then
+		echo "Using custom scalar map found at $LOCAL_CUSTOM_SCALARS. Delete this file to disable"
 
-  if [[ -v MCP_HEADERS ]]; then
-    IFS=',' read -ra HEADERS <<< "$MCP_HEADERS"
-    for header in "${HEADERS[@]}"; do
-      ARGS+=(--header "$header")
-    done
-  fi
+		export APOLLO_MCP_CUSTOM_SCALARS="$LOCAL_CUSTOM_SCALARS"
+	fi
 
-  if [[ -v MCP_SSE ]]; then
-      ARGS+=(--sse-address 0.0.0.0)
-    else
-      ARGS+=(--http-address 0.0.0.0)
-  fi
+	# For the operation source, the user can either place operations in the
+	# right folder, or place a PQ manifest. If both are supplied, then the PQ manifest
+	# takes precedence.
+	if [[ -f "$LOCAL_PQ_MANIFEST" ]]; then
+		echo "Using persisted query manifest found at $LOCAL_PQ_MANIFEST."
+		echo "  NOTE: If you wish to use local operations in $LOCAL_OPERATIONS instead, make sure to remove the manifest first"
 
-  if [[ -v MCP_INTROSPECTION ]]; then
-   ARGS+=(--introspection)
-  fi
+		export APOLLO_MCP_OPERATIONS__SOURCE="manifest"
+		export APOLLO_MCP_OPERATIONS__PATH="$LOCAL_PQ_MANIFEST"
+	elif [ "$(ls -A $LOCAL_OPERATIONS)" ]; then
+		echo "Using operations contained in $LOCAL_OPERATIONS"
 
-  if [[ -v MCP_UPLINK_MANIFEST ]]; then
-    ARGS+=(--uplink-manifest)
-  fi
+		export APOLLO_MCP_OPERATIONS__SOURCE="local"
+		export APOLLO_MCP_OPERATIONS__PATHS="[$LOCAL_OPERATIONS]"
+	fi
 
-  if [[ -v MCP_COLLECTION ]]; then
-    ARGS+=(--collection "$MCP_COLLECTION")
-  fi
-
-  # Only pass through operations if the folder contains files
-  if [ "$(ls -A /config/operations)" ]; then
-   ARGS+=(--operations /config/operations)
-  fi
-
-  if [[ -v MCP_EXPLORER ]]; then
-    ARGS+=(--explorer)
-  fi
-
-  if [[ -f /config/persisted_queries_manifest.json ]]; then
-    ARGS+=(--manifest /config/persisted_queries_manifest.json)
-  fi
-
-  if [[ -v MCP_DISABLE_TYPE_DESCRIPTION ]]; then
-      ARGS+=(--disable-type-description)
-  fi
-
-  if [[ -v MCP_DISABLE_SCHEMA_DESCRIPTION ]]; then
-        ARGS+=(--disable-schema-description)
-  fi
-
-  if [[ -v MCP_ALLOW_MUTATIONS ]]; then
-    ARGS+=(--allow-mutations "$MCP_ALLOW_MUTATIONS")
-  fi
-
-  if [[ -v MCP_LOG_LEVEL ]]; then
-    ARGS+=(--log "$MCP_LOG_LEVEL")
-  fi
-
-  exec /opt/apollo-mcp-server "${ARGS[@]}"
+	exec /opt/apollo-mcp-server "/config/mcp_config.yaml"
 else
-  while true; do sleep 10000; done
+	while true; do sleep 10000; done
 fi
-


### PR DESCRIPTION
This PR updates the MCP run script to use the new config file instead of arguments to comply with breaking changes in the MCP server with version `0.6.0`.

Documentation has been updated to reflect the change in env var handling and to point users towards the new example config file.

BREAKING: Certain environment variables are now ignored.