### PR TITLE
Fix Otelcol binary location

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -45,7 +45,7 @@ RUN case $TARGETARCH in \
 RUN tar -C / -Jxpf /tmp/s6.tar.xz && rm -r /tmp/s6.tar.xz
 
 # Copy our otel collector into our final image
-COPY --from=otel /otelcol-contrib /otelcol-contrib
+COPY --from=otel /otelcol-contrib /opt/otelcol-contrib
 COPY --from=otel /etc/otelcol-contrib /etc/otelcol-contrib
 
 # Install our otelcol service definition

--- a/examples/datadog/otel-collector/router_config.yaml
+++ b/examples/datadog/otel-collector/router_config.yaml
@@ -22,7 +22,7 @@ telemetry:
       supergraph: # Apollo specific attribute options: https://www.apollographql.com/docs/graphos/routing/observability/telemetry/instrumentation/standard-attributes#supergraph
         attributes:
           otel.name: supergraph
-          operation.name: "taco"
+          operation.name: "supergraph"
           resource.name:
             operation_name: string
           otel.status_code:  # This attribute will be set to true if the response from the router contained errors in the response body and will mark spans as Error in the APM UI.


### PR DESCRIPTION
when trying to use the apollo-runtime container and engage the otel collector I got the message
> router-1  | ./run: line 7: /opt/otelcol-contrib: No such file or directory

It seems that the binary is at /otelcol-contrib (root directory), not /opt/otelcol-contrib. The s6 run script and the docker file didn't match up. I've corrected the dockerfile