### PR TITLE
docs: change MCP's default port from 5000 to 8000

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,12 +34,12 @@ docker run \
 --env MCP_ENABLE=1 \
 --rm \
 -p 4000:4000 \
--p 5050:5000 \
+-p 8000:8000 \
 ghcr.io/apollographql/apollo-runtime:latest
 ```
 We open two ports in the above command:
 - 4000 is where the router is listening. Make your GraphQL queries here.
-- 5050 is where the MCP server is mounted, specifically at the `/mcp` path. Connect your assistants to this port.
+- 8000 is where the MCP server is mounted, specifically at the `/mcp` path. Connect your assistants to this port.
 
 ### Running the MCP Server
 

--- a/examples/compose.yaml
+++ b/examples/compose.yaml
@@ -4,7 +4,7 @@ services:
     build: ..
     ports:
       - "4000:4000"
-      - "5050:5000"
+      - "8000:8000"
     volumes:
       - type: bind
         source: ./router_config.yaml


### PR DESCRIPTION
<-- https://apollographql.atlassian.net/browse/AIR-42 -->

MCP's default port is change from 5000 to 5000.

(Keep this open until https://github.com/apollographql/apollo-mcp-server/pull/417 is released)