### PR TITLE
Bundle default mcp_config.yaml in image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -69,6 +69,9 @@ RUN mkdir -p /etc/s6-overlay/s6-rc.d/user/contents.d/router
 # Install our mcp server
 RUN curl -sSL "https://mcp.apollo.dev/download/nix/v${APOLLO_MCP_SERVER_VERSION}" | sh
 
+# Add a default copy of the mcp config file
+ADD config/mcp_config.yaml /config/mcp_config.yaml
+
 # Install our mcp service definition
 ADD s6_service_definitions/mcp /etc/s6-overlay/s6-rc.d/mcp
 


### PR DESCRIPTION
The s6 run script for the MCP service runs `/opt/apollo-mcp-server "/config/mcp_config.yaml"` without any conditions. However, the Dockerfile only includes `router_config.yaml` and doesn't copy the `mcp_config.yaml` file into `/config`. So, when you follow the README quickstart with just the environment variables and no volume mount, the router starts up fine, but MCP keeps crashing with the error: `Error: failed to read config file '/config/mcp_config.yaml': No such file or directory (os error 2)`. This PR adds the missing line `ADD config/mcp_config.yaml /config/mcp_config.yaml`, which matches how `router_config.yaml` is already included.

Before:

```sh
$ docker run --rm \
  --env APOLLO_GRAPH_REF=<your-federated-graph@variant> \
  --env APOLLO_KEY=<your-key> \
  --env MCP_ENABLE=1 \
  -p 4000:4000 -p 8000:8000 \
  ghcr.io/apollographql/apollo-runtime:latest
```

```sh
2026-05-04T21:48:36.050055Z INFO  Health check exposed at http://127.0.0.1:8088/health
2026-05-04T21:48:36.065087Z INFO  GraphQL endpoint exposed at http://0.0.0.0:4000/ 🚀
2026-05-04T21:48:36.066859Z INFO  state machine transitioned event="UpdateSchema" state=Running previous_state="Startup"
Error: failed to read config file '/config/mcp_config.yaml': No such file or directory (os error 2)
Error: failed to read config file '/config/mcp_config.yaml': No such file or directory (os error 2)
Error: failed to read config file '/config/mcp_config.yaml': No such file or directory (os error 2)
```

After:

```sh
$ git fetch origin fix/bundle-mcp-config && git checkout fix/bundle-mcp-config
$ docker build -t apollo-runtime:fix-test .
$ docker run --rm \
  --env APOLLO_GRAPH_REF=<your-federated-graph@variant> \
  --env APOLLO_KEY=<your-key> \
  --env MCP_ENABLE=1 \
  -p 4000:4000 -p 8000:8000 \
  apollo-runtime:fix-test
```

```sh
2026-05-04T21:51:10.358002Z INFO  Health check exposed at http://127.0.0.1:8088/health
2026-05-04T21:51:10.370198Z INFO  GraphQL endpoint exposed at http://0.0.0.0:4000/ 🚀
2026-05-04T21:51:10.370590Z INFO  state machine transitioned event="UpdateLicense(Licensed)" state=Running previous_state="Startup"
trace_id=257dfa9ebd09ce451c582a92adfc3aee 2026-05-04T21:51:10.415792Z  INFO load_tool: Tool MessageQuery1 loaded with a character count of 55. Estimated tokens: 13
trace_id=e024bd4da30c90e0f784e94ff887cfd9 2026-05-04T21:51:10.416074Z  INFO load_tool: Tool CartQuery3 loaded with a character count of 52. Estimated tokens: 13
trace_id=fb3e3f3b90230241865bc1472029b5e8 2026-05-04T21:51:10.416333Z  INFO load_tool: Tool CommentQuery2 loaded with a character count of 55. Estimated tokens: 13
```