### PR TITLE
Port workflows to release-tooling

### DIFF
--- a/.github/workflows/main-skip.yml
+++ b/.github/workflows/main-skip.yml
@@ -1,0 +1,19 @@
+name: Build Apollo Runtime Container (Skip)
+
+# Sibling stub for the real `main.yml` workflow. Triggers on the paths
+# the real workflow ignores so that branch protection's required check
+# resolves on PRs that only touch docs or examples. Job name must stay
+# in lockstep with `main.yml`'s scan job.
+
+on:
+  pull_request:
+    paths:
+      - '*.md'
+      - 'examples/**'
+
+jobs:
+  scan:
+    name: Wiz Security Scan
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "Docs/examples-only change; real scan skipped."

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,48 +14,50 @@ on:
     paths-ignore:
       - '*.md'
       - 'examples/**'
+
 env:
-  REGISTRY: ghcr.io
   NAMESPACED_REGISTRY: ghcr.io/apollographql/apollo-runtime
   NAMESPACED_DOCKERHUB_REGISTRY: apollograph/apollo-runtime
-  PLATFORMS: linux/arm64,linux/amd64
 
 jobs:
-  build-and-push-image:
-    name: Build and Push Docker Image
+  compute-versions:
+    name: Compute Versions
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
-      packages: write
-      attestations: write
-      id-token: write
+    outputs:
+      runtime_version: ${{ steps.runtime-version.outputs.runtime_version }}
+      router_version: ${{ steps.dockerfile-versions.outputs.router }}
+      mcp_server_version: ${{ steps.dockerfile-versions.outputs.mcp }}
+      composite_version: ${{ steps.composite.outputs.composite_version }}
+      release_title: ${{ steps.composite.outputs.release_title }}
+      tags: ${{ steps.tags.outputs.tags }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8
         with:
           fetch-depth: 0
-      - name: Add Tool To Parse Dockerfiles
+      - name: Add tool to parse Dockerfile
         uses: taiki-e/install-action@parse-dockerfile
-      - name: Get Versions From Dockerfile
-        id: get-versions
+      - name: Extract dependency versions from Dockerfile
+        id: dockerfile-versions
         run: |
           VERSIONS=$(parse-dockerfile Dockerfile | jq -cr '[.instructions[] | select(.kind=="LABEL" or .kind=="ARG") | select(.arguments.value | contains("org.opencontainers.image") or startswith("APOLLO_")).arguments.value | match("([^=]*)=(.*)") | .captures | {(.[0].string) : .[1].string}] | add')
-          echo "versions=$VERSIONS" >> "$GITHUB_OUTPUT"
-      - name: Get Latest Version Tag
-        id: get-latest-version
+          echo "router=$(echo "$VERSIONS" | jq -r '.APOLLO_ROUTER_VERSION')" >> "$GITHUB_OUTPUT"
+          echo "mcp=$(echo "$VERSIONS" | jq -r '.APOLLO_MCP_SERVER_VERSION')" >> "$GITHUB_OUTPUT"
+      - name: Get latest version tag
+        id: latest-tag
         run: |
           LATEST_VERSION=$(git tag -l '0.0.*' | grep -oE '^[0-9]+\.[0-9]+\.[0-9]+' | sort -uV | tail -1)
           echo "version=${LATEST_VERSION}" >> "$GITHUB_OUTPUT"
-      - name: Compute Next Semver
+      - name: Compute next semver
         id: next-semver
-        if: steps.get-latest-version.outputs.version != ''
-        uses: WyriHaximus/github-action-next-semvers@637b84e300ba3a3efb9794fc77d40708bab734aa
+        if: steps.latest-tag.outputs.version != ''
+        uses: WyriHaximus/github-action-next-semvers@18aa9ed4152808ab99b88d71f5481e41f8d89930
         with:
-          version: ${{ steps.get-latest-version.outputs.version }}
-      - name: Compute Runtime Version
-        id: compute-runtime-version
+          version: ${{ steps.latest-tag.outputs.version }}
+      - name: Compute runtime version
+        id: runtime-version
         run: |
-          if [ -z "${{ steps.get-latest-version.outputs.version }}" ]; then
+          if [ -z "${{ steps.latest-tag.outputs.version }}" ]; then
             NEXT_VERSION="0.0.1"
           else
             NEXT_VERSION="${{ steps.next-semver.outputs.patch }}"
@@ -65,64 +67,74 @@ jobs:
           else
             echo "runtime_version=${NEXT_VERSION}" >> "$GITHUB_OUTPUT"
           fi
-      - name: Remove Quotes From Title & Description
+      - name: Compute composite version and release title
+        id: composite
         env:
-          DESCRIPTION: ${{ fromJSON(steps.get-versions.outputs.versions)['org.opencontainers.image.description'] }}
-          TITLE: ${{ fromJSON(steps.get-versions.outputs.versions)['org.opencontainers.image.title'] }}
-        id: remove-quotes
+          RV: ${{ steps.runtime-version.outputs.runtime_version }}
+          ROUTER: ${{ steps.dockerfile-versions.outputs.router }}
+          MCP: ${{ steps.dockerfile-versions.outputs.mcp }}
         run: |
-          STRIPPED_DESCRIPTION=${DESCRIPTION//\"/}
-          echo "description=$STRIPPED_DESCRIPTION" >> "$GITHUB_OUTPUT"
-          STRIPPED_TITLE=${TITLE//\"/}
-          echo "title=$STRIPPED_TITLE" >> "$GITHUB_OUTPUT"
-      - name: Get Docker Metadata
-        id: meta
-        uses: docker/metadata-action@4378dc6be7f72231dfe78ac7e0364a44f1c9f54b
+          echo "composite_version=${RV}_router${ROUTER}_mcp-server${MCP}" >> "$GITHUB_OUTPUT"
+          echo "release_title=Apollo Runtime Container - v${RV} (Router - v${ROUTER}, MCP Server - v${MCP})" >> "$GITHUB_OUTPUT"
+      - name: Compose publish tag list
+        id: tags
         env:
-          DOCKER_METADATA_PR_HEAD_SHA: true
+          RV: ${{ steps.runtime-version.outputs.runtime_version }}
+          ROUTER: ${{ steps.dockerfile-versions.outputs.router }}
+          MCP: ${{ steps.dockerfile-versions.outputs.mcp }}
+        run: |
+          {
+            echo 'tags<<EOF'
+            echo "type=raw,value=${RV}"
+            echo "type=raw,value=${RV}_router${ROUTER}"
+            echo "type=raw,value=${RV}_mcp-server${MCP}"
+            echo "type=raw,value=${RV}_router${ROUTER}_mcp-server${MCP}"
+            echo "type=raw,value=latest"
+            echo "type=raw,value=latest_router${ROUTER}"
+            echo "type=raw,value=latest_mcp-server${MCP}"
+            echo "type=raw,value=latest_router${ROUTER}_mcp-server${MCP}"
+            echo 'EOF'
+          } >> "$GITHUB_OUTPUT"
+
+  build:
+    name: Build and Push to Internal Registry
+    uses: apollographql/release-tooling/.github/workflows/build_and_publish.yml@9412d54a53b46cc3ad53a9ff2869d3e23a147a71
+    with:
+      image_name: apollo-runtime
+      image_description: A GraphQL Runtime for serving Supergraphs and enabling AI
+      platforms: '[{"platform":"linux/amd64","runner":"ubuntu-latest"},{"platform":"linux/arm64","runner":"ubuntu-24.04-arm"}]'
+      context: .
+      dockerfile_location: ./Dockerfile
+
+  scan:
+    name: Wiz Security Scan
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8
+      - name: Resolve image SHA tag
+        id: sha
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            echo "tag=${{ github.event.pull_request.head.sha }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "tag=${{ github.sha }}" >> "$GITHUB_OUTPUT"
+          fi
+      - name: Pull image from internal registry
+        id: pull
+        uses: apollographql/release-tooling/pull-image@9412d54a53b46cc3ad53a9ff2869d3e23a147a71
         with:
-          images: |
-            ${{ env.NAMESPACED_REGISTRY }}
-            apollograph/apollo-runtime
-          tags: |
-            type=semver,pattern={{version}},value=${{ steps.compute-runtime-version.outputs.runtime_version }}
-            type=raw,value=${{ steps.compute-runtime-version.outputs.runtime_version }}_router${{ fromJSON(steps.get-versions.outputs.versions).APOLLO_ROUTER_VERSION }}
-            type=raw,value=${{ steps.compute-runtime-version.outputs.runtime_version }}_mcp-server${{ fromJSON(steps.get-versions.outputs.versions).APOLLO_MCP_SERVER_VERSION }}
-            type=raw,value=${{ steps.compute-runtime-version.outputs.runtime_version }}_router${{ fromJSON(steps.get-versions.outputs.versions).APOLLO_ROUTER_VERSION }}_mcp-server${{ fromJSON(steps.get-versions.outputs.versions).APOLLO_MCP_SERVER_VERSION }}
-            type=raw,value=latest,enable={{is_default_branch}}
-            type=raw,value=latest_router${{ fromJSON(steps.get-versions.outputs.versions).APOLLO_ROUTER_VERSION }},enable={{is_default_branch}}
-            type=raw,value=latest_mcp-server${{ fromJSON(steps.get-versions.outputs.versions).APOLLO_MCP_SERVER_VERSION }},enable={{is_default_branch}}
-            type=raw,value=latest_router${{ fromJSON(steps.get-versions.outputs.versions).APOLLO_ROUTER_VERSION }}_mcp-server${{ fromJSON(steps.get-versions.outputs.versions).APOLLO_MCP_SERVER_VERSION }},enable={{is_default_branch}}
-          labels: |
-            org.opencontainers.image.version=${{ steps.compute-runtime-version.outputs.runtime_version }}
-            org.opencontainers.image.description=${{ steps.remove-quotes.outputs.description }} 
-            org.opencontainers.image.title=${{ steps.remove-quotes.outputs.title }}
-          annotations: |
-            org.opencontainers.image.version=${{ steps.compute-runtime-version.outputs.runtime_version }}
-            org.opencontainers.image.description=${{ steps.remove-quotes.outputs.description }} 
-            org.opencontainers.image.title=${{ steps.remove-quotes.outputs.title }}
-      - name: Log in to the Container Registry
-        uses: docker/login-action@a0d57b8e43b6ef1cca20559d68cec2227e63fccd
-        with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@6804d313191b81cfc5feb5065848250370954232
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@172dff065fb2e54aaed577fd667975cd412819fb
-      - name: Build and Load Docker Image For Testing
-        id: build-for-testing
-        uses: docker/build-push-action@b66d8774c665b789105b440514f0c97e6f19b06f
-        with:
-          load: true
-          tags: ${{ env.NAMESPACED_REGISTRY }}:test
-          platforms: linux/amd64
+          image_name: apollo-runtime
+          tag: ${{ steps.sha.outputs.tag }}
       - name: Scan Image
         uses: docker://public-registry.wiz.io/wiz-app/wizcli@sha256:408d7651cf2bb05f614d04605d34a9639c806329d227022d988722679fadc0f9
         with:
           args: >-
-            scan container-image ${{ env.NAMESPACED_REGISTRY }}:test
+            scan container-image ${{ steps.pull.outputs.image_reference }}
             --dockerfile Dockerfile
             --policies "Apollo-Default-Vulnerabilities-Policy"
             --sbom-format spdx-json
@@ -130,52 +142,85 @@ jobs:
             --timeout "0h9m0s"
             --client-id ${{ secrets.WIZ_CLIENT_ID_V1 }}
             --client-secret ${{ secrets.WIZ_CLIENT_SECRET_V1 }}
-      - name: Log in to the GitHub Container Registry
-        uses: docker/login-action@a0d57b8e43b6ef1cca20559d68cec2227e63fccd
+
+  release_dockerhub:
+    name: Publish to DockerHub
+    needs: [compute-versions, scan]
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    outputs:
+      digest: ${{ steps.publish.outputs.digest }}
+    steps:
+      - name: Publish to DockerHub
+        id: publish
+        uses: apollographql/release-tooling/release-dockerhub@9412d54a53b46cc3ad53a9ff2869d3e23a147a71
         with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Authenticate With GCP
-        id: auth
-        uses: "google-github-actions/auth@fc2174804b84f912b1f6d334e9463f484f1c552d"
+          image_name: apollo-runtime
+          commit_sha: ${{ github.sha }}
+          tag_latest: 'false'
+          tags: ${{ needs.compute-versions.outputs.tags }}
+
+  release_ghcr:
+    name: Publish to GHCR
+    needs: [compute-versions, scan]
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+    steps:
+      - name: Publish to GHCR
+        uses: apollographql/release-tooling/release-ghcr@9412d54a53b46cc3ad53a9ff2869d3e23a147a71
         with:
-          token_format: "access_token"
-          project_id: "platform-mgmt-service-e0izz"
-          service_account: "runtime-container-ci@platform-mgmt-service-e0izz.iam.gserviceaccount.com"
-          workload_identity_provider: "projects/865738624352/locations/global/workloadIdentityPools/github-d8bck/providers/github-d8bck"
-      - name: Fetch DockerHub Credential
+          image_name: apollo-runtime
+          commit_sha: ${{ github.sha }}
+          tags: ${{ needs.compute-versions.outputs.tags }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+
+  release:
+    name: Attest and Create GitHub Release
+    needs: [compute-versions, release_dockerhub, release_ghcr]
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      attestations: write
+      id-token: write
+    steps:
+      - name: Authenticate with GCP
+        id: gcp-auth
+        uses: google-github-actions/auth@fc2174804b84f912b1f6d334e9463f484f1c552d
+        with:
+          token_format: access_token
+          project_id: platform-mgmt-service-e0izz
+          service_account: release-tooling-automation@platform-mgmt-service-e0izz.iam.gserviceaccount.com
+          workload_identity_provider: projects/865738624352/locations/global/workloadIdentityPools/github-d8bck/providers/github-d8bck
+      - name: Fetch DockerHub credential
         id: gsm
         uses: google-github-actions/get-secretmanager-secrets@bc9c54b29fdffb8a47776820a7d26e77b379d262
         with:
           secrets: |-
             token:platform-prod-service-q8dyj/docker_hub_push_token
-      - name: Docker Auth
-        uses: docker/login-action@a0d57b8e43b6ef1cca20559d68cec2227e63fccd
+      - name: Log in to DockerHub
+        uses: docker/login-action@6862ffc5ab2cdb4405cf318a62a6f4c066e2298b
         with:
-          username: "apollograph"
-          password: "${{ steps.gsm.outputs.token }}"
-      - name: Build and Push Docker image
-        id: push
-        uses: docker/build-push-action@b66d8774c665b789105b440514f0c97e6f19b06f
-        with:
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          annotations: ${{ steps.meta.outputs.annotations }}
-          labels: ${{ steps.meta.outputs.labels }}
-          platforms: ${{ env.PLATFORMS }}
+          username: apollograph
+          password: ${{ steps.gsm.outputs.token }}
       - name: Generate artifact attestation
         uses: actions/attest-build-provenance@v4
         with:
           subject-name: index.docker.io/${{ env.NAMESPACED_DOCKERHUB_REGISTRY }}
-          subject-digest: ${{ steps.push.outputs.digest }}
+          subject-digest: ${{ needs.release_dockerhub.outputs.digest }}
           push-to-registry: true
       - name: Create GitHub Release
-        if: ${{ github.event_name != 'pull_request' }}
         uses: comnoco/create-release-action@6ac85b5a67d93e181c1a8f97072e2e3ffc582ec4
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          tag_name: ${{ steps.compute-runtime-version.outputs.runtime_version }}_router${{ fromJSON(steps.get-versions.outputs.versions).APOLLO_ROUTER_VERSION }}_mcp-server${{ fromJSON(steps.get-versions.outputs.versions).APOLLO_MCP_SERVER_VERSION }}
-          release_name: Apollo Runtime Container - v${{ steps.compute-runtime-version.outputs.runtime_version }} (Router - v${{ fromJSON(steps.get-versions.outputs.versions).APOLLO_ROUTER_VERSION }}, MCP Server - v${{ fromJSON(steps.get-versions.outputs.versions).APOLLO_MCP_SERVER_VERSION }})
-          body: Find the latest release at ${{ env.NAMESPACED_REGISTRY }}:${{ steps.compute-runtime-version.outputs.runtime_version }}_router${{ fromJSON(steps.get-versions.outputs.versions).APOLLO_ROUTER_VERSION }}_mcp-server${{ fromJSON(steps.get-versions.outputs.versions).APOLLO_MCP_SERVER_VERSION }} or ${{ env.NAMESPACED_DOCKERHUB_REGISTRY }}:${{ steps.compute-runtime-version.outputs.runtime_version }}_router${{ fromJSON(steps.get-versions.outputs.versions).APOLLO_ROUTER_VERSION }}_mcp-server${{ fromJSON(steps.get-versions.outputs.versions).APOLLO_MCP_SERVER_VERSION }}.
+          tag_name: ${{ needs.compute-versions.outputs.composite_version }}
+          release_name: ${{ needs.compute-versions.outputs.release_title }}
+          body: Find the latest release at ${{ env.NAMESPACED_REGISTRY }}:${{ needs.compute-versions.outputs.composite_version }} or ${{ env.NAMESPACED_DOCKERHUB_REGISTRY }}:${{ needs.compute-versions.outputs.composite_version }}.


### PR DESCRIPTION
This repo was concieved in an era before we had release-tooling, so now we do, let's strip back the workflows we have so they're off-loading responsibility as much as possible